### PR TITLE
アドバイス投稿（提案）フローを追加

### DIFF
--- a/app/controllers/advice_suggestions_controller.rb
+++ b/app/controllers/advice_suggestions_controller.rb
@@ -1,0 +1,28 @@
+class AdviceSuggestionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @advice_suggestions = current_user.advice_suggestions.includes(:category).order(created_at: :desc)
+  end
+
+  def new
+    @advice_suggestion = current_user.advice_suggestions.new
+  end
+
+  def create
+    @advice_suggestion = current_user.advice_suggestions.new(advice_suggestion_params)
+    @advice_suggestion.status = :pending
+
+    if @advice_suggestion.save
+      redirect_to advice_suggestions_path, notice: "投稿を受け付けました！ありがとうございます。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def advice_suggestion_params
+    params.require(:advice_suggestion).permit(:category_id, :body)
+  end
+end

--- a/app/helpers/advice_suggestions_helper.rb
+++ b/app/helpers/advice_suggestions_helper.rb
@@ -1,0 +1,2 @@
+module AdviceSuggestionsHelper
+end

--- a/app/models/advice_suggestion.rb
+++ b/app/models/advice_suggestion.rb
@@ -1,0 +1,8 @@
+class AdviceSuggestion < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+
+  enum :status, { pending: 0, approved: 1, rejected: 2 }, prefix: true
+
+  validates :body, presence: true
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
   has_many :advices, dependent: :destroy
+  has_many :advice_suggestions, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :advice_suggestions, dependent: :destroy
 end

--- a/app/views/advice_suggestions/index.html.erb
+++ b/app/views/advice_suggestions/index.html.erb
@@ -1,0 +1,29 @@
+<h1>投稿履歴</h1>
+
+<% if notice.present? %>
+  <p style="color: green;"><%= notice %></p>
+<% end %>
+
+<% if @advice_suggestions.any? %>
+  <ul>
+    <% @advice_suggestions.each do |s| %>
+      <% status_label =
+           if s.status_pending?
+             "承認待ち"
+           elsif s.status_approved?
+             "承認済み"
+           else
+             "非公開"
+           end
+      %>
+      <li>
+        [<%= status_label %>] <%= s.category.name %>：<%= s.body.truncate(60) %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだ投稿はありません。</p>
+<% end %>
+
+<p><%= link_to "新しく投稿する", new_advice_suggestion_path %></p>
+<p><%= link_to "← 掲示板へ戻る", root_path %></p>

--- a/app/views/advice_suggestions/new.html.erb
+++ b/app/views/advice_suggestions/new.html.erb
@@ -1,0 +1,25 @@
+<h1>アドバイス投稿</h1>
+
+<% if @advice_suggestion.errors.any? %>
+  <ul>
+    <% @advice_suggestion.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: @advice_suggestion do |f| %>
+  <div>
+    <%= f.label :category_id, "カテゴリ" %><br>
+    <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= f.label :body, "内容" %><br>
+    <%= f.text_area :body, rows: 6 %>
+  </div>
+
+  <%= f.submit "送信" %>
+<% end %>
+
+<p><%= link_to "← 掲示板へ戻る", root_path %></p>

--- a/app/views/shared/_auth_links.html.erb
+++ b/app/views/shared/_auth_links.html.erb
@@ -1,5 +1,6 @@
 <div style="position: fixed; top: 8px; right: 12px; z-index: 9999; font-size: 12px;">
   <% if user_signed_in? %>
+    <%= link_to "投稿", new_advice_suggestion_path %> /
     <%= link_to "設定", settings_path %> /
     <span><%= current_user.email %></span>
     <%= button_to "ログアウト",
@@ -11,3 +12,4 @@
     <%= link_to "新規登録", new_user_registration_path %>
   <% end %>
 </div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :advice_suggestions, only: [ :index, :new, :create ]
   get "settings", to: "settings#index"
   devise_for :users
   # RESTfulなルーティング

--- a/db/migrate/20260119144330_create_advice_suggestions.rb
+++ b/db/migrate/20260119144330_create_advice_suggestions.rb
@@ -1,0 +1,12 @@
+class CreateAdviceSuggestions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :advice_suggestions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+      t.text :body
+      t.integer :status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_19_125612) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_19_144330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "advice_suggestions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.text "body"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_advice_suggestions_on_category_id"
+    t.index ["user_id"], name: "index_advice_suggestions_on_user_id"
+  end
 
   create_table "advices", force: :cascade do |t|
     t.bigint "category_id", null: false
@@ -53,5 +64,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_125612) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "advice_suggestions", "categories"
+  add_foreign_key "advice_suggestions", "users"
   add_foreign_key "advices", "categories"
 end


### PR DESCRIPTION
## 概要
ログインユーザーが掲示板向けのアドバイスを投稿（提案）できるフローを追加しました。
投稿は即公開せず、承認待ち（pending）として保存されます。

## 実装内容
- アドバイス投稿用モデル（AdviceSuggestion）を追加
- ログイン必須の投稿フォーム（new/create）を実装
- 投稿履歴一覧（index）を実装（自分の投稿のみ表示）
- 投稿ステータスを日本語表示（承認待ち / 承認済み / 非公開）
- 投稿完了時にサンクスメッセージを表示
- 右上ナビゲーションに「投稿」導線を追加

## 動作確認
- 未ログイン状態で投稿ページにアクセスするとログイン画面へリダイレクトされる
- ログイン後、カテゴリ選択＋本文入力で投稿できる
- 投稿後、投稿履歴ページに遷移しサンクスメッセージが表示される
- 投稿履歴に日本語ステータスが表示される

## 補足
- 承認フロー（pending → approved）や管理者画面は別ブランチで実装予定
- 既存の掲示板表示（Advice）とは分離した設計にしています
