### PR TITLE
プロフィール表示画面を新規作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 ruby "3.2.3"
+
 gem "rails", "~> 8.0.3"
 gem "propshaft"
 gem "pg", "~> 1.1"
@@ -9,22 +10,25 @@ gem "importmap-rails"
 gem "turbo-rails"
 gem "stimulus-rails"
 gem "jbuilder"
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[windows jruby]
+
 gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
+
 gem "bootsnap", require: false
 gem "kamal", require: false
 gem "thruster", require: false
 
 group :development, :test do
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
   gem "brakeman", require: false
   gem "rubocop-rails-omakase", require: false
 end
 
 group :development do
   gem "web-console"
+  gem "erb-formatter"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (5.0.2)
+    erb-formatter (0.7.3)
+      syntax_tree (~> 6.0)
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
@@ -198,6 +200,7 @@ GEM
     pg (1.6.2-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
+    prettier_print (1.2.1)
     prettyprint (0.2.0)
     prism (1.5.1)
     propshaft (1.3.1)
@@ -324,6 +327,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    syntax_tree (6.3.0)
+      prettier_print (>= 1.2.0)
     thor (1.4.0)
     thruster (0.1.15)
     thruster (0.1.15-aarch64-linux)
@@ -373,6 +378,7 @@ DEPENDENCIES
   brakeman
   debug
   devise (~> 4.9)
+  erb-formatter
   importmap-rails
   jbuilder
   kamal

--- a/app/assets/builds/app.css
+++ b/app/assets/builds/app.css
@@ -497,7 +497,7 @@ body.owl-show-page {
 }
 
 /* =========================================================
-  📝 遷移図寄せ：アドバイス案募集フォーム（赤寄り）
+  📝 遷移図寄せ：アドバイス案募集フォーム
 ========================================================= */
 .page-container.advice-form {
   width: min(1040px, calc(100% - 32px));
@@ -557,14 +557,14 @@ body.owl-show-page {
   max-height: 55vh;
 }
 
-/* 注意文（赤系に寄せすぎず、落ち着き） */
+/* 注意文 */
 .page-container.advice-form .form-note {
   margin: 12px 0 16px;
   font-size: 13px;
   color: rgba(60, 0, 0, 0.65);
 }
 
-/* 投稿ボタン：えんじ */
+/* 投稿ボタン */
 .page-container.advice-form .form-actions {
   display: flex;
   justify-content: flex-end;
@@ -1161,16 +1161,16 @@ body.owl-show-page {
 /* ヘッダーの色を強めて “ページ感” を出す */
 .page-container.user-settings-index .page-header,
 .page-container.user-settings-page .page-header {
-  background: linear-gradient(180deg, #3f5bd9 0%, #2e3f9f 100%);
+  background: linear-gradient(200deg, #3f5bd9 0%, #2e3f9f 100%);
   border-bottom: 1px solid rgba(0,0,0,0.12);
 }
 
 .page-container.user-settings-index .page-header h1,
 .page-container.user-settings-page .page-header h1 {
-   text-align: center;
+  text-align: center;
   color: #ffd000;
-  text-shadow: 0 2px 10px rgba(0,0,0,0.25);
-  letter-spacing: 0.06em;
+  text-shadow: 0 2px 5px rgba(0,0,0,0.25);
+  letter-spacing: 0.05em;
 }
 
 .page-container.user-settings-page .notice,

--- a/app/assets/builds/owls.css
+++ b/app/assets/builds/owls.css
@@ -687,7 +687,285 @@
 }
 
 /* =========================================================
-  🕊️ 5. SHOWページ（プロフィール）
+  👤 ミニプロフィール（トップ右側カード用）
+  - 右上カードの最上部に出る「アイコン + 名前 + ひとこと」
+  - 未設定でも見た目が自然 / 文字のはみ出し防止
+========================================================= */
+
+.user-mini-profile--link{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  width: fit-content;
+  max-width: 100%;
+
+  /* 右寄せ + メニューとの隙間 */
+  margin: 6px 0 14px auto;
+  padding: 8px 12px;
+
+  text-decoration: none;
+  color: inherit;
+
+  border-radius: 14px;
+  background: rgba(255,255,255,0.18);
+  border: 1px solid rgba(255,255,255,0.22);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.10);
+
+  /* ガラス感ちょい足し（嫌なら消してOK） */
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+
+  transition: transform 0.15s ease, filter 0.15s ease, box-shadow 0.15s ease;
+}
+
+.user-mini-profile--link:hover{
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(0,0,0,0.14);
+}
+
+.user-mini-profile--link:active{
+  transform: translateY(0);
+}
+
+/* 右側テキスト */
+.user-mini-profile__text{
+  text-align: right;
+  min-width: 0;
+}
+
+/* 名前（長い時に省略） */
+.user-mini-profile__name{
+  font-weight: 900;
+  font-size: 14px;
+  line-height: 1.2;
+
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ひとこと（1行で省略して崩れ防止） */
+.user-mini-profile__bio{
+  font-size: 12px;
+  opacity: 0.9;
+  line-height: 1.2;
+
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* アイコン枠 */
+.user-mini-profile__avatar{
+  width: 44px;
+  height: 44px;
+  border-radius: 9999px;
+  overflow: hidden;
+
+  display: grid;
+  place-items: center;
+
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255,255,255,0.55);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+
+  flex: 0 0 44px;
+
+  /* 画像をきれいに見せる系（効くことがある） */
+  transform: translateZ(0);
+}
+
+/* 画像 */
+.user-mini-profile__img{
+  width: 100%;
+  height: 100%;
+  display: block;
+
+  object-fit: cover;
+  object-position: center;
+
+  /* 変なフィルタで滲むの防止 */
+  filter: none;
+
+  /* ちょい安定（効く環境がある） */
+  backface-visibility: hidden;
+}
+
+/* プレースホルダー（頭文字） */
+.user-mini-profile__placeholder{
+  font-weight: 900;
+  font-size: 18px;
+  color: rgba(0,0,0,0.78);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.35);
+}
+
+/* スマホ微調整 */
+@media (max-width: 768px){
+  .user-mini-profile__name,
+  .user-mini-profile__bio{
+    max-width: 140px;
+  }
+
+  .user-mini-profile__avatar{
+    width: 40px;
+    height: 40px;
+    flex-basis: 40px;
+  }
+
+  .user-mini-profile__placeholder{
+    font-size: 16px;
+  }
+}
+
+/* =========================================================
+  ミニプロフィール遷移先ページスタイル
+========================================================= */
+
+.profile-page {
+  width: min(1040px, calc(100% - 32px));
+  margin: 60px auto;
+}
+
+/* 見出し帯 */
+.profile-page .page-header {
+  margin-bottom: 18px;
+}
+
+.profile-page .page-header h1 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  color: #1e2a1f;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.65);
+}
+
+/* 本体カード */
+.profile-card {
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.12);
+  overflow: hidden;
+}
+
+/* 上部ヘッダー */
+.profile-card::before{
+  content:"";
+  display:block;
+  height: 110px;
+  background: radial-gradient(circle at 30% 20%, rgba(120,255,170,0.35), transparent 55%),
+              linear-gradient(90deg, rgba(60,200,120,0.22), rgba(255,200,80,0.18));
+}
+
+/* 内側 */
+.profile-card {
+  padding: 0;
+}
+
+.profile-card .profile-avatar,
+.profile-card .profile-info,
+.profile-card .form-actions,
+.profile-card .settings-subnav {
+  padding: 18px 24px;
+}
+
+/* アバター：丸＋縁＋浮かせる */
+.profile-avatar {
+  margin-top: -55px;
+  display: grid;
+  place-items: center;
+  padding-bottom: 6px;
+}
+
+.profile-avatar .avatar-img,
+.profile-avatar .avatar-placeholder {
+  width: 120px;
+  height: 120px;
+  border-radius: 9999px;
+  overflow: hidden;
+
+  border: 3px solid rgba(255,255,255,0.9);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
+  background: rgba(255,255,255,0.35);
+}
+
+.profile-avatar .avatar-img{
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.profile-avatar .avatar-placeholder{
+  display: grid;
+  place-items: center;
+  font-weight: 900;
+  font-size: 34px;
+  color: rgba(20,40,25,0.75);
+}
+
+/* 情報：見出しっぽく整える */
+.profile-info p{
+  margin: 10px 0;
+  line-height: 1.7;
+  color: #172317;
+}
+
+.profile-info strong{
+  display: inline-block;
+  width: 70px;
+  color: rgba(20,40,25,0.75);
+}
+
+/* ボタン類 */
+.form-actions{
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.primary-btn{
+  display: inline-block;
+  padding: 10px 14px;
+  border-radius: 12px;
+  text-decoration: none;
+  font-weight: 800;
+
+  background: rgba(255, 153, 0, 0.85);
+  border: 1px solid rgba(255,153,0,0.45);
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(0,0,0,0.12);
+
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.primary-btn:hover{
+  filter: brightness(1.03);
+  transform: translateY(-1px);
+}
+
+.settings-subnav{
+  border-top: 1px solid rgba(0,0,0,0.06);
+}
+
+.sub-link{
+  color: rgba(20,40,25,0.75);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.sub-link:hover{
+  text-decoration: underline;
+}
+
+/* =========================================================
+  🕊️ 5. SHOWページ
    ========================================================= */
 body.owl-show-page {
   background-image: url('tisikinomori_fuyu.png');

--- a/app/controllers/owls_controller.rb
+++ b/app/controllers/owls_controller.rb
@@ -10,7 +10,7 @@ class OwlsController < ApplicationController
       }
     )
 
-    # ▼追加：ログイン中ユーザーがお気に入りしてる Advice のID一覧
+    # ログイン中ユーザーがお気に入りしてる Advice のID一覧
     @favorite_ids =
       if user_signed_in?
         current_user.favorites.pluck(:advice_id)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,15 +1,21 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!
 
+  def show
+    @profile = current_user.profile || current_user.build_profile
+  end
+
   def edit
-    @profile = current_user.profile || current_user.create_profile
+    @profile = current_user.profile || current_user.build_profile
   end
 
   def update
-    @profile = current_user.profile || current_user.create_profile
+    @profile = current_user.profile || current_user.build_profile
 
     if @profile.update(profile_params)
-      redirect_to settings_path, notice: "プロフィールを更新しました"
+      redirect_to profile_path, notice: "プロフィールを更新しました"
+      # 設定ハブに戻す場合↓
+      # redirect_to settings_path, notice: "プロフィールを更新しました"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,6 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  has_one_attached :avatar
 
   validates :display_name, length: { maximum: 30 }, allow_blank: true
   validates :bio, length: { maximum: 300 }, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   # 👤 プロフィール
   has_one :profile, dependent: :destroy
-  after_create :ensure_profile
+  after_create_commit :ensure_profile!
 
   def admin?
     admin == true
@@ -20,7 +20,10 @@ class User < ApplicationRecord
 
   private
 
-  def ensure_profile
-    create_profile! unless profile
+  # User作成を失敗させないため「作れなかったらログだけ」にする
+  def ensure_profile!
+    create_profile! if profile.nil?
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("[ensure_profile!] user_id=#{id} profile create failed: #{e.message}")
   end
 end

--- a/app/views/owls/index.html.erb
+++ b/app/views/owls/index.html.erb
@@ -1,111 +1,145 @@
-<div class="classroom-container"
+<div
+  class="classroom-container"
   data-controller="owl coming-soon"
   data-owl-categories-value="<%= json_escape(@categories_json.to_json) %>"
   data-owl-signed-in-value="<%= user_signed_in? %>"
-  data-owl-favorite-ids-value="<%= json_escape(@favorite_ids.to_json) %>">
-
+  data-owl-favorite-ids-value="<%= json_escape(@favorite_ids.to_json) %>"
+>
   <!-- 🌳 森の背景 -->
-  <img src="<%= asset_path('tisikinomori.png') %>"
-       alt="森の背景"
-       class="forest-bg"
-       data-owl-target="forest"
-       data-autumn-image="<%= asset_path('tisikinomori_aki.png') %>">
+  <img
+    src="<%= asset_path('tisikinomori.png') %>"
+    alt="森の背景"
+    class="forest-bg"
+    data-owl-target="forest"
+    data-autumn-image="<%= asset_path('tisikinomori_aki.png') %>"
+  >
 
+  <!-- 🚧 β版バナー -->
   <div class="dev-banner">
     🚧 現在β版（開発中）です。データは予告なく削除される可能性があります。
   </div>
 
   <!-- 🎓 黒板 -->
   <div class="blackboard" data-owl-target="blackboard">
-    <button class="chalk-text-button"
-            data-owl-target="click"
-            data-action="click->owl#enterForest">
+    <button
+      class="chalk-text-button"
+      data-owl-target="click"
+      data-action="click->owl#enterForest"
+    >
       <span class="typing-text" data-owl-target="typingText"></span>
     </button>
   </div>
 
   <!-- 🦉 フクちゃん -->
-  <img src="<%= asset_path('fukuchan.png') %>"
-       alt="フクちゃん"
-       class="fukuchan-global"
-       data-owl-target="fukuchan"
-       data-happy-image="<%= asset_path('fukuchan-happy.png') %>"
-       data-normal-image="<%= asset_path('fukuchan.png') %>">
+  <img
+    src="<%= asset_path('fukuchan.png') %>"
+    alt="フクちゃん"
+    class="fukuchan-global"
+    data-owl-target="fukuchan"
+    data-happy-image="<%= asset_path('fukuchan-happy.png') %>"
+    data-normal-image="<%= asset_path('fukuchan.png') %>"
+  >
 
   <!-- ⏰ リアルタイム時計 -->
   <div data-controller="clock">
-    <div id="current-time" class="clock-display" data-clock-target="display"></div>
+    <div
+      id="current-time"
+      class="clock-display"
+      data-clock-target="display"
+    ></div>
   </div>
 
   <!-- 🎵 BGM -->
-  <div class="bgm-controls"
-       data-controller="bgm"
-       data-bgm-path="<%= asset_path('forest_ambient.mp3') %>">
-    <button data-bgm-target="toggleButton"
-            data-action="click->bgm#toggle"
-            class="bgm-btn">
+  <div
+    class="bgm-controls"
+    data-controller="bgm"
+    data-bgm-path="<%= asset_path('forest_ambient.mp3') %>"
+  >
+    <button
+      data-bgm-target="toggleButton"
+      data-action="click->bgm#toggle"
+      class="bgm-btn"
+    >
       森のBGM
     </button>
-    <input type="range"
-           data-bgm-target="volumeSlider"
-           data-action="input->bgm#adjustVolume"
-           min="0" max="0.3" step="0.01" value="0.15"
-           class="volume-slider">
+
+    <input
+      type="range"
+      data-bgm-target="volumeSlider"
+      data-action="input->bgm#adjustVolume"
+      min="0"
+      max="0.3"
+      step="0.01"
+      value="0.15"
+      class="volume-slider"
+    >
   </div>
 
-  <!-- 🦉 プロフィール一覧 -->
+  <!-- 🦉 メニューカード一覧 -->
   <div class="owls-container" style="display: none;">
     <% @owls.each_with_index do |owl, index| %>
-      <div class="owl-card owl-menu-card"
-           data-owl-target="owlCard"
-           data-owl-index="<%= index %>"
-           data-action="mouseenter->owl#hoverOwl mouseleave->owl#leaveOwl">
+      <div
+        class="owl-card owl-menu-card"
+        data-owl-target="owlCard"
+        data-owl-index="<%= index %>"
+        data-action="mouseenter->owl#hoverOwl mouseleave->owl#leaveOwl"
+      >
+        <!-- 👤 ログインユーザー ミニプロフィール -->
+        <% if user_signed_in? %>
+          <% profile = current_user.profile %>
 
-        <!-- メニュー（通常：リンク運用  -->
+          <%= link_to profile_path, class: "user-mini-profile user-mini-profile--link" do %>
+            <div class="user-mini-profile__avatar">
+              <% if profile&.avatar&.attached? %>
+                <%= image_tag profile.avatar, class: "user-mini-profile__img" %>
+              <% else %>
+                <div class="user-mini-profile__placeholder">
+                  <span aria-hidden="true">👤</span>
+                </div>
+              <% end %>
+            </div>
+
+            <div class="user-mini-profile__text">
+              <div class="user-mini-profile__name">
+                <%= profile&.display_name.presence || current_user.email.split("@").first %>
+              </div>
+
+              <% if profile&.bio.present? %>
+                <div class="user-mini-profile__bio">
+                  <%= profile.bio %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <!-- 📋 メニュー -->
         <div class="owl-menu">
-
-          <!-- ユーザー設定 -->
           <%= link_to "ユーザー設定", settings_path, class: "owl-menu-btn" %>
-          <%# <button type="button"
-                class="owl-menu-btn"
-                data-action="click->coming-soon#comingSoon"
-                data-feature="ユーザー設定">ユーザー設定</button> %>
-
-          <!-- お気に入り（一覧） -->
           <%= link_to "お気に入り", favorites_path, class: "owl-menu-btn" %>
-          <%# <button type="button"
-                class="owl-menu-btn"
-                data-action="click->coming-soon#comingSoon"
-                data-feature="お気に入り">お気に入り</button> %>
-
-          <!-- アドバイス案募集 -->
           <%= link_to "アドバイス案募集", new_advice_suggestion_path, class: "owl-menu-btn" %>
-          <%# <button type="button"
-                class="owl-menu-btn"
-                data-action="click->coming-soon#comingSoon"
-                data-feature="アドバイス案募集">アドバイス案募集</button> %>
-
-          <!-- 投稿一覧（advice_suggestions#index） -->
           <%= link_to "投稿一覧", advice_suggestions_path, class: "owl-menu-btn" %>
-          <%# <button type="button"
-                class="owl-menu-btn"
-                data-action="click->coming-soon#comingSoon"
-                data-feature="投稿一覧">投稿一覧</button> %>
 
-          <!-- アプリ設定 -->
-          <%#= link_to "アプリ設定", app_settings_path, class: "owl-menu-btn" %>
-          <button type="button"
-                class="owl-menu-btn"
-                data-action="click->coming-soon#comingSoon"
-                data-feature="アプリ設定">アプリ設定</button>
+          <button
+            type="button"
+            class="owl-menu-btn"
+            data-action="click->coming-soon#comingSoon"
+            data-feature="アプリ設定"
+          >
+            アプリ設定
+          </button>
         </div>
 
-        <!-- メッセージ（静的） -->
+        <!-- 💬 メッセージ -->
         <div class="owl-message">
-          <div class="message-line"
-               data-message="<%= "こんにちは！僕は梟🦉の#{owl.name}" %>"></div>
-          <div class="message-line"
-               data-message="沢山の人を笑顔にするのが仕事だホウ〜☆彡"></div>
+          <div
+            class="message-line"
+            data-message="<%= "こんにちは！僕は梟🦉の#{owl.name}" %>"
+          ></div>
+          <div
+            class="message-line"
+            data-message="沢山の人を笑顔にするのが仕事だホウ〜☆彡"
+          ></div>
         </div>
 
         <%= link_to "詳しく見る", owl_path(owl), class: "owl-menu-btn primary" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -20,8 +20,8 @@
         </div>
 
         <div class="form-group">
-          <%= f.label :avatar, "アイコンURL（任意）" %>
-          <%= f.text_field :avatar %>
+          <%= f.label :avatar, "アイコン画像（任意）" %>
+          <%= f.file_field :avatar, accept: "image/*" %>
         </div>
 
         <div class="form-actions">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,49 @@
+<div class="page-container profile-page">
+  <div class="page-header">
+    <h1>プロフィール</h1>
+  </div>
+
+  <div class="page-body">
+    <section class="settings-section">
+      <div class="profile-card">
+
+        <%# =========================
+           表示名・アイコンのフォールバック
+           - display_name があればそれ
+           - なければ emailの@より前
+           - それも無理なら "?"
+        ========================= %>
+        <% fallback_name = @profile.display_name.presence || current_user.email.to_s.split("@").first %>
+        <% initial = fallback_name.to_s[0]&.upcase || "?" %>
+
+        <div class="profile-avatar">
+          <% if @profile.avatar.attached? %>
+            <%= image_tag @profile.avatar, class: "avatar-img" %>
+          <% else %>
+            <div class="avatar-placeholder"><%= initial %></div>
+          <% end %>
+        </div>
+
+        <div class="profile-info">
+          <p><strong>表示名：</strong><%= fallback_name %></p>
+
+          <% if @profile.bio.present? %>
+            <p><strong>ひとこと：</strong><%= simple_format(@profile.bio.to_s) %></p>
+          <% else %>
+            <p><strong>ひとこと：</strong><span class="muted">（未設定）</span></p>
+          <% end %>
+        </div>
+
+        <div class="form-actions">
+          <%= link_to "編集する", edit_profile_path, class: "primary-btn" %>
+        </div>
+
+        <div class="settings-subnav">
+          <%= link_to "ユーザー設定へ戻る", settings_path, class: "sub-link" %>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+
+<%= render "shared/back_to_board" %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,9 +1,18 @@
 ja:
   devise:
+    # =========================
+    # セッション（ログイン / ログアウト）
+    # =========================
     sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+
       new:
         sign_in: "ログイン"
 
+    # =========================
+    # 新規登録 / アカウント編集
+    # =========================
     registrations:
       new:
         sign_up: "新規登録"
@@ -13,6 +22,9 @@ ja:
         cancel_my_account: "退会する"
         are_you_sure: "本当によろしいですか？"
 
+    # =========================
+    # パスワード再設定
+    # =========================
     passwords:
       new:
         forgot_your_password: "パスワードをお忘れですか？"
@@ -23,13 +35,26 @@ ja:
         confirm_new_password: "新しいパスワード（確認）"
         change_my_password: "パスワードを変更する"
 
+    # =========================
+    # メール確認
+    # =========================
     confirmations:
       new:
         resend_confirmation_instructions: "確認メールを再送する"
 
+    # =========================
+    # 共通リンク
+    # =========================
     shared:
       links:
         sign_in: "ログイン"
         sign_up: "新規登録"
         forgot_your_password: "パスワードを忘れた方はこちら"
         didn_t_receive_confirmation_instructions: "確認メールが届かない場合"
+
+    # =========================
+    # 失敗時メッセージ（重要）
+    # =========================
+    failure:
+      invalid: "メールアドレスまたはパスワードが違います。"
+      unauthenticated: "ログインしてください。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   get "settings", to: "settings#index"
 
   # 👤 プロフィール（単数）
-  resource :profile, only: [ :edit, :update ]
+  resource :profile, only: %i[show edit update]
 
   #  Devise分離（メール / パスワード / 退会）
   namespace :users do

--- a/db/migrate/20260129121427_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260129121427_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_25_105212) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_29_121427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "advice_suggestions", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -94,6 +122,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_25_105212) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "advice_suggestions", "categories"
   add_foreign_key "advice_suggestions", "users"
   add_foreign_key "advices", "categories"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,8 +3,8 @@
 # =========================================================
 Owl.find_or_initialize_by(name: "フクちゃん").tap do |owl|
   owl.species     = "学習サポートフクロウ"
-  owl.age         = 26
-  owl.habitat     = "RUNTEQ 知識の森"
+  owl.age         = 28
+  owl.habitat     = "知識の森"
   owl.description = "学習者に寄り添い、つまずきをやさしく案内してくれるフクロウ"
   owl.save!
 end


### PR DESCRIPTION
## 概要
プロフィール編集画面は既に存在していましたが、
プロフィール内容を確認するための表示専用ページがなかったため、
新たにプロフィール表示画面を追加しました。

## 変更内容
- プロフィール表示用ページを新規作成
- 表示名・ひとこと・アイコンを確認できるUIを実装
- 既存の編集画面・データ構造には変更なし

## 補足
- プロフィール編集機能自体の挙動は変更していません
- デザインは既存の世界観に合わせて調整しています
