### PR TITLE
プロフィール更新時の500エラーを修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,9 +41,9 @@ Rails.application.configure do
   config.silence_healthcheck_path = "/up"
   config.active_support.report_deprecations = false
   config.cache_store = :solid_cache_store
-  #config.active_job.queue_adapter = :solid_queue
+  # config.active_job.queue_adapter = :solid_queue
   config.active_job.queue_adapter = :async
-  #config.solid_queue.connects_to = { database: { writing: :queue } }
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
   config.action_mailer.default_url_options = { host: "example.com" }
   config.i18n.fallbacks = true
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
## 概要
本番環境でプロフィール更新時に500エラーが発生していたため修正しました。

## 変更内容
- ActiveJobのキューアダプタを solid_queue から async に変更

## 背景
Render環境でSolidQueue使用時にジョブのenqueueに失敗し、
ActiveStorageの処理が500エラーになる事象を確認したため。

## 確認内容
- 本番環境でプロフィール更新が正常に完了すること
