### PR TITLE
承認後のAdvice化フロー実装と管理・表示ロジック整理

### DIFF
--- a/app/controllers/admin/advice_suggestions_controller.rb
+++ b/app/controllers/admin/advice_suggestions_controller.rb
@@ -1,46 +1,95 @@
+# app/controllers/admin/advice_suggestions_controller.rb
 class Admin::AdviceSuggestionsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_admin!
+  before_action :set_advice_suggestion, only: %i[
+    show destroy new_advice create_advice reject restore delete_forever
+  ]
 
   def index
-    base = AdviceSuggestion.includes(:user, :category)
+    base = AdviceSuggestion.includes(:user, :category, :advice)
 
     @pending  = base.status_pending.order(created_at: :asc)
     @approved = base.status_approved.order(created_at: :desc)
     @rejected = base.status_rejected.order(created_at: :desc)
+    @deleted  = base.status_deleted.order(updated_at: :desc)
   end
 
   def show
-    @advice_suggestion = AdviceSuggestion.includes(:user, :category).find(params[:id])
   end
 
-  def approve
-    suggestion = AdviceSuggestion.find(params[:id])
+  # 編集して公開フォーム（承認後の更新もここを使う）
+  def new_advice
+    @advice = Advice.find_or_initialize_by(advice_suggestion_id: @advice_suggestion.id)
+    @advice.category ||= @advice_suggestion.category
+
+    # ✅ 初回（まだ公開Adviceが無い時）だけ下書きを入れる
+    if @advice.new_record?
+      @advice.title = @advice_suggestion.title.presence || @advice_suggestion.body.to_s.truncate(30)
+      @advice.body  = @advice_suggestion.body.to_s
+    end
+  end
+
+  # 公開（作成 or 更新）
+  def create_advice
+    advice = Advice.find_or_initialize_by(advice_suggestion_id: @advice_suggestion.id)
 
     ActiveRecord::Base.transaction do
-      suggestion.update!(status: :approved)
+      advice.assign_attributes(advice_params)
 
-      Advice.create!(
-        category_id: suggestion.category_id,
-        title: suggestion.body.truncate(30),
-        body: suggestion.body
-      )
+      # 投稿のカテゴリに寄せたいなら =（常に上書き）
+      # advice.category_id = @advice_suggestion.category_id
+      # 既存を尊重するなら ||=（今のあなたの意図ならこっちでもOK）
+      advice.category_id ||= @advice_suggestion.category_id
+
+      advice.save!
+      @advice_suggestion.update!(status: :approved)
     end
 
-    redirect_to admin_advice_suggestions_path, notice: "承認しました"
+    redirect_to admin_advice_suggestions_path, notice: "公開しました"
+  rescue ActiveRecord::RecordInvalid
+    @advice = advice
+    flash.now[:alert] = "入力内容を確認してください"
+    render :new_advice, status: :unprocessable_entity
   end
 
   def reject
-    suggestion = AdviceSuggestion.find(params[:id])
-    suggestion.update!(status: :rejected)
-
+    @advice_suggestion.update!(status: :rejected)
     redirect_to admin_advice_suggestions_path, notice: "却下しました"
+  end
+
+  # ゴミ箱へ（物理削除ではない）
+  def destroy
+    @advice_suggestion.advice&.destroy!
+    @advice_suggestion.update!(status: :deleted)
+    redirect_to admin_advice_suggestions_path, notice: "ゴミ箱に移動しました"
+  end
+
+  # ゴミ箱から復元（承認待ちへ戻す）
+  def restore
+    @advice_suggestion.update!(status: :pending)
+    redirect_to admin_advice_suggestions_path, notice: "承認待ちに戻しました"
+  end
+
+  # 完全削除（戻せない）
+  def delete_forever
+    @advice_suggestion.destroy!
+    redirect_to admin_advice_suggestions_path, notice: "完全に削除しました"
   end
 
   private
 
+  def set_advice_suggestion
+    @advice_suggestion = AdviceSuggestion.includes(:user, :category, :advice).find(params[:id])
+  end
+
+  def advice_params
+    params.require(:advice).permit(:title, :body)
+  end
+
   def require_admin!
     return if current_user&.admin?
+
     redirect_to root_path, alert: "権限がありません"
   end
 end

--- a/app/controllers/admin/advices_controller.rb
+++ b/app/controllers/admin/advices_controller.rb
@@ -1,0 +1,41 @@
+# app/controllers/admin/advices_controller.rb
+class Admin::AdvicesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin!
+  before_action :set_advice, only: %i[show edit update destroy]
+
+  def index
+    @advices = Advice.includes(:category).order(created_at: :desc)
+  end
+
+  def show; end
+  def edit; end
+
+  def update
+    if @advice.update(advice_params)
+      redirect_to admin_advice_path(@advice), notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @advice.destroy!
+    redirect_to admin_advices_path, notice: "削除しました"
+  end
+
+  private
+
+  def set_advice
+    @advice = Advice.find(params[:id])
+  end
+
+  def advice_params
+    params.require(:advice).permit(:title, :body, :category_id)
+  end
+
+  def require_admin!
+    return if current_user&.admin?
+    redirect_to root_path, alert: "権限がありません"
+  end
+end

--- a/app/controllers/advice_suggestions_controller.rb
+++ b/app/controllers/advice_suggestions_controller.rb
@@ -3,7 +3,7 @@ class AdviceSuggestionsController < ApplicationController
   before_action :set_trouble_category, only: %i[new create]
 
   def index
-    base = current_user.advice_suggestions.includes(:category).order(created_at: :desc)
+    base = current_user.advice_suggestions.includes(:category, :advice).order(created_at: :desc)
 
     @pending  = base.select(&:status_pending?)
     @approved = base.select(&:status_approved?)

--- a/app/models/advice.rb
+++ b/app/models/advice.rb
@@ -1,5 +1,6 @@
 class Advice < ApplicationRecord
   belongs_to :category
+  belongs_to :advice_suggestion, optional: true
 
   validates :title, presence: true
   validates :body, presence: true

--- a/app/models/advice_suggestion.rb
+++ b/app/models/advice_suggestion.rb
@@ -2,7 +2,10 @@ class AdviceSuggestion < ApplicationRecord
   belongs_to :user
   belongs_to :category
 
-  enum :status, { pending: 0, approved: 1, rejected: 2 }, prefix: true
+  # 🔹 公開されたAdviceとの関連（1投稿につき1公開）
+  has_one :advice, dependent: :nullify
+
+  enum :status, { pending: 0, approved: 1, rejected: 2, deleted: 3 }, prefix: true
 
   before_validation :set_default_category, on: :create
 
@@ -14,6 +17,7 @@ class AdviceSuggestion < ApplicationRecord
   def set_default_category
     return if category_id.present?
 
-    self.category = Category.find_by(name: "みんなのお悩み解決")
+    default_category = Category.find_by(name: "みんなのお悩み解決")
+    self.category = default_category if default_category.present?
   end
 end

--- a/app/views/admin/advice_suggestions/index.html.erb
+++ b/app/views/admin/advice_suggestions/index.html.erb
@@ -17,7 +17,7 @@
           <thead>
             <tr>
               <th>投稿者</th>
-              <th>カテゴリ</th>
+              <th>タイトル</th>
               <th>内容</th>
               <th>操作</th>
             </tr>
@@ -26,21 +26,26 @@
             <% @pending.each do |s| %>
               <tr>
                 <td><%= s.user.display_name_or_email %></td>
-                <td><%= s.category.name %></td>
+
+                <!-- タイトル（リンク） -->
                 <td class="admin-body-preview">
                   <%= link_to admin_advice_suggestion_path(s) do %>
-                    <%= s.body.truncate(80) %>
+                    <%= s.title.presence || s.body.to_s.truncate(30) %>
                   <% end %>
                   <div class="admin-detail-link">
                     <%= link_to "詳細を見る", admin_advice_suggestion_path(s) %>
                   </div>
                 </td>
+
+                <!-- 本文プレビュー -->
+                <td>
+                  <%= s.body.to_s.truncate(80) %>
+                </td>
+
                 <td>
                   <div class="admin-actions">
-                    <%= button_to "承認",
-                          approve_admin_advice_suggestion_path(s),
-                          method: :patch,
-                          form: { class: "admin-actions__form" },
+                    <%= link_to "編集して公開",
+                          new_advice_admin_advice_suggestion_path(s),
                           class: "admin-btn approve" %>
 
                     <%= button_to "却下",
@@ -69,25 +74,48 @@
           <thead>
             <tr>
               <th>投稿者</th>
-              <th>カテゴリ</th>
+              <th>タイトル</th>
               <th>内容</th>
               <th>ステータス</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <% @approved.each do |s| %>
+              <% published = s.advice %>
               <tr>
                 <td><%= s.user.display_name_or_email %></td>
-                <td><%= s.category.name %></td>
+
+                <!--  承認済みは「公開内容（Advice）」を優先表示 -->
                 <td class="admin-body-preview">
                   <%= link_to admin_advice_suggestion_path(s) do %>
-                    <%= s.body.truncate(80) %>
+                    <%= (published&.title.presence || s.title.presence || s.body.to_s.truncate(30)) %>
                   <% end %>
                   <div class="admin-detail-link">
                     <%= link_to "詳細を見る", admin_advice_suggestion_path(s) %>
                   </div>
                 </td>
+
+                <td>
+                  <%= (published&.body.presence || s.body.to_s).truncate(80) %>
+                </td>
+
                 <td>承認済み</td>
+
+                <td>
+                  <div class="admin-actions">
+                    <!--  承認後の修正（アップデート）導線 -->
+                    <%= link_to "公開内容を編集",
+                          new_advice_admin_advice_suggestion_path(s),
+                          class: "admin-btn detail" %>
+
+                    <%= button_to "ゴミ箱へ",
+                          admin_advice_suggestion_path(s),
+                          method: :delete,
+                          data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
+                          class: "admin-btn danger" %>
+                  </div>
+                </td>
               </tr>
             <% end %>
           </tbody>
@@ -108,31 +136,107 @@
           <thead>
             <tr>
               <th>投稿者</th>
-              <th>カテゴリ</th>
+              <th>タイトル</th>
               <th>内容</th>
               <th>ステータス</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody>
             <% @rejected.each do |s| %>
               <tr>
                 <td><%= s.user.display_name_or_email %></td>
-                <td><%= s.category.name %></td>
+
                 <td class="admin-body-preview">
                   <%= link_to admin_advice_suggestion_path(s) do %>
-                    <%= s.body.truncate(80) %>
+                    <%= s.title.presence || s.body.to_s.truncate(30) %>
                   <% end %>
                   <div class="admin-detail-link">
                     <%= link_to "詳細を見る", admin_advice_suggestion_path(s) %>
                   </div>
                 </td>
+
+                <td>
+                  <%= s.body.to_s.truncate(80) %>
+                </td>
+
                 <td>却下</td>
+
+                <td>
+                  <div class="admin-actions">
+                    <%= button_to "ゴミ箱へ",
+                          admin_advice_suggestion_path(s),
+                          method: :delete,
+                          data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
+                          class: "admin-btn danger" %>
+                  </div>
+                </td>
               </tr>
             <% end %>
           </tbody>
         </table>
       <% else %>
         <p class="empty">却下はありません。</p>
+      <% end %>
+    </section>
+
+    <hr>
+
+    <!-- ゴミ箱 -->
+    <section class="admin-section">
+      <h2>ゴミ箱（<%= @deleted.size %>件）</h2>
+
+      <% if @deleted.any? %>
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th>投稿者</th>
+              <th>タイトル</th>
+              <th>内容</th>
+              <th>ステータス</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @deleted.each do |s| %>
+              <tr>
+                <td><%= s.user.display_name_or_email %></td>
+
+                <td class="admin-body-preview">
+                  <%= link_to admin_advice_suggestion_path(s) do %>
+                    <%= s.title.presence || s.body.to_s.truncate(30) %>
+                  <% end %>
+                  <div class="admin-detail-link">
+                    <%= link_to "詳細を見る", admin_advice_suggestion_path(s) %>
+                  </div>
+                </td>
+
+                <td>
+                  <%= s.body.to_s.truncate(80) %>
+                </td>
+
+                <td>削除済み</td>
+
+                <td>
+                  <div class="admin-actions">
+                    <%= button_to "復元",
+                          restore_admin_advice_suggestion_path(s),
+                          method: :patch,
+                          class: "admin-btn detail" %>
+
+                    <%= button_to "完全削除",
+                          delete_forever_admin_advice_suggestion_path(s),
+                          method: :delete,
+                          data: { turbo_confirm: "完全に削除します。元に戻せません。よろしいですか？" },
+                          class: "admin-btn danger" %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="empty">ゴミ箱は空です。</p>
       <% end %>
     </section>
   </div>

--- a/app/views/admin/advice_suggestions/new_advice.html.erb
+++ b/app/views/admin/advice_suggestions/new_advice.html.erb
@@ -1,0 +1,88 @@
+<div class="page-container admin-advice-suggestions-page admin-advice-suggestion-new">
+  <div class="page-header">
+    <h1>編集して公開</h1>
+  </div>
+
+  <div class="page-body">
+
+    <% if flash[:alert].present? %>
+      <p class="alert"><%= flash[:alert] %></p>
+    <% end %>
+
+    <!-- 投稿メタ情報 -->
+    <div class="admin-show-meta">
+      <div class="admin-show-meta__row">
+        <span class="label">投稿者</span>
+        <span class="value"><%= @advice_suggestion.user.display_name_or_email %></span>
+      </div>
+
+      <div class="admin-show-meta__row">
+        <span class="label">タイトル</span>
+        <span class="value"><%= @advice_suggestion.title.presence || @advice_suggestion.body.to_s.truncate(30) %></span>
+      </div>
+
+      <div class="admin-show-meta__row">
+        <span class="label">投稿日時</span>
+        <span class="value"><%= l(@advice_suggestion.created_at) %></span>
+      </div>
+    </div>
+
+    <hr>
+
+    <h2 class="admin-show-title">元の投稿（原文）</h2>
+
+    <div class="admin-original-box" style="margin-bottom: 20px;">
+      <div class="admin-original-box__body">
+        <%= simple_format(h(@advice_suggestion.body)) %>
+      </div>
+      <div class="admin-original-box__note">
+        ※原文は確認用に随時保存。編集は下のフォームから実行。
+      </div>
+    </div>
+
+    <hr>
+
+    <h2 class="admin-show-title">公開用に編集</h2>
+
+    <% if @advice.errors.any? %>
+      <div class="admin-errors">
+        <p class="admin-errors__title">入力に不備があります</p>
+        <ul class="admin-errors__list">
+          <% @advice.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with model: @advice,
+          url: create_advice_admin_advice_suggestion_path(@advice_suggestion),
+          local: true do |f| %>
+
+      <div class="admin-form-group">
+        <%= f.label :title, "タイトル" %>
+        <%= f.text_field :title, class: "admin-input" %>
+        <p class="admin-form-hint">※一覧で見やすい短いタイトル推奨（10文字前後）</p>
+      </div>
+
+      <div class="admin-form-group">
+        <%= f.label :body, "本文" %>
+        <%= f.text_area :body, rows: 12, class: "admin-textarea" %>
+      </div>
+
+      <div class="admin-actions">
+        <%= f.submit "公開する", class: "admin-btn approve" %>
+
+        <%= link_to "詳細に戻る",
+              admin_advice_suggestion_path(@advice_suggestion),
+              class: "admin-btn detail" %>
+
+        <%= link_to "一覧に戻る",
+              admin_advice_suggestions_path,
+              class: "admin-btn detail" %>
+      </div>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/admin/advice_suggestions/show.html.erb
+++ b/app/views/admin/advice_suggestions/show.html.erb
@@ -5,23 +5,20 @@
 
   <div class="page-body">
     <div class="admin-show-meta">
-      <!-- 投稿者 -->
       <div class="admin-show-meta__row">
         <span class="label">投稿者</span>
-        <span class="value">
-          <%= @advice_suggestion.user.display_name_or_email %>
-        </span>
+        <span class="value"><%= @advice_suggestion.user.display_name_or_email %></span>
       </div>
 
-      <!-- カテゴリ -->
       <div class="admin-show-meta__row">
-        <span class="label">カテゴリ</span>
+        <span class="label">タイトル</span>
         <span class="value">
-          <%= @advice_suggestion.category.name %>
+          <%= @advice_suggestion.advice&.title.presence ||
+              @advice_suggestion.title.presence ||
+              "（未入力）" %>
         </span>
       </div>
 
-      <!-- ステータス -->
       <div class="admin-show-meta__row">
         <span class="label">ステータス</span>
         <span class="value">
@@ -29,43 +26,76 @@
             <span class="status-badge pending">承認待ち</span>
           <% elsif @advice_suggestion.status_approved? %>
             <span class="status-badge approved">承認済み</span>
+          <% elsif @advice_suggestion.status_deleted? %>
+            <span class="status-badge rejected">ゴミ箱</span>
           <% else %>
             <span class="status-badge rejected">却下</span>
           <% end %>
         </span>
       </div>
 
-      <!-- 投稿日時（日本式） -->
       <div class="admin-show-meta__row">
         <span class="label">投稿日時</span>
-        <span class="value">
-          <%= l(@advice_suggestion.created_at) %>
-        </span>
+        <span class="value"><%= l(@advice_suggestion.created_at) %></span>
       </div>
     </div>
 
     <hr>
 
-    <h2 class="admin-show-title">本文</h2>
+    <!-- 公開内容（Advice）があれば上に出す -->
+    <% if @advice_suggestion.advice.present? %>
+      <h2 class="admin-show-title">公開内容（掲示板に出る内容）</h2>
 
+      <div class="admin-show-meta">
+        <div class="admin-show-meta__row">
+          <span class="label">公開タイトル</span>
+          <span class="value"><%= @advice_suggestion.advice.title %></span>
+        </div>
+      </div>
+
+      <div class="admin-show-body">
+        <%= simple_format(h(@advice_suggestion.advice.body)) %>
+      </div>
+
+      <hr>
+    <% end %>
+
+    <!-- 元の投稿（原文） -->
+    <h2 class="admin-show-title">元の投稿（原文）</h2>
     <div class="admin-show-body">
       <%= simple_format(h(@advice_suggestion.body)) %>
     </div>
 
     <div class="admin-show-actions">
-      <% if @advice_suggestion.status_pending? %>
-        <div class="admin-actions">
-          <%= button_to "承認",
-                approve_admin_advice_suggestion_path(@advice_suggestion),
-                method: :patch,
+      <div class="admin-actions">
+        <!-- 承認待ち：編集して公開 / 却下 -->
+        <% if @advice_suggestion.status_pending? %>
+          <%= link_to "編集して公開",
+                new_advice_admin_advice_suggestion_path(@advice_suggestion),
                 class: "admin-btn approve" %>
 
           <%= button_to "却下",
                 reject_admin_advice_suggestion_path(@advice_suggestion),
                 method: :patch,
                 class: "admin-btn reject" %>
-        </div>
-      <% end %>
+        <% end %>
+
+        <!-- 承認済み：公開内容を編集（アップデート） -->
+        <% if @advice_suggestion.status_approved? %>
+          <%= link_to "公開内容を編集",
+                new_advice_admin_advice_suggestion_path(@advice_suggestion),
+                class: "admin-btn detail" %>
+        <% end %>
+
+        <!-- ゴミ箱へ（deleted は表示しない） -->
+        <% unless @advice_suggestion.status_deleted? %>
+          <%= button_to "ゴミ箱へ",
+                admin_advice_suggestion_path(@advice_suggestion),
+                method: :delete,
+                data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
+                class: "admin-btn danger" %>
+        <% end %>
+      </div>
 
       <div class="admin-show-links">
         <%= link_to "一覧に戻る",

--- a/app/views/admin/advices/edit.html.erb
+++ b/app/views/admin/advices/edit.html.erb
@@ -1,0 +1,29 @@
+<div class="page-container admin-advices-page admin-advice-edit">
+  <div class="page-header">
+    <h1>公開済みアドバイスを編集</h1>
+  </div>
+
+  <div class="page-body">
+    <%= form_with model: @advice, url: admin_advice_path(@advice), local: true do |f| %>
+      <div class="admin-form-group">
+        <%= f.label :category_id, "カテゴリ" %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, {}, class: "admin-input" %>
+      </div>
+
+      <div class="admin-form-group">
+        <%= f.label :title, "タイトル" %>
+        <%= f.text_field :title, class: "admin-input" %>
+      </div>
+
+      <div class="admin-form-group">
+        <%= f.label :body, "本文" %>
+        <%= f.text_area :body, rows: 12, class: "admin-textarea" %>
+      </div>
+
+      <div class="admin-actions">
+        <%= f.submit "更新する", class: "admin-btn approve" %>
+        <%= link_to "戻る", admin_advices_path, class: "admin-btn detail" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/advices/index.html.erb
+++ b/app/views/admin/advices/index.html.erb
@@ -1,0 +1,49 @@
+<div class="page-container admin-advices-page">
+  <div class="page-header">
+    <h1>公開済みアドバイス一覧</h1>
+  </div>
+
+  <div class="page-body">
+    <% if notice.present? %>
+      <p class="notice"><%= notice %></p>
+    <% end %>
+
+    <% if @advices.any? %>
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>カテゴリ</th>
+            <th>タイトル</th>
+            <th>更新日時</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @advices.each do |a| %>
+            <tr>
+              <td><%= a.category&.name %></td>
+              <td><%= link_to a.title, admin_advice_path(a) %></td>
+              <td><%= l(a.updated_at) %></td>
+              <td>
+                <div class="admin-actions">
+                  <%= link_to "編集", edit_admin_advice_path(a), class: "admin-btn detail" %>
+                  <%= button_to "削除",
+                        admin_advice_path(a),
+                        method: :delete,
+                        data: { turbo_confirm: "削除します。よろしいですか？" },
+                        class: "admin-btn danger" %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="empty">公開済みアドバイスはありません。</p>
+    <% end %>
+
+    <div class="admin-show-links" style="margin-top: 16px;">
+      <%= link_to "承認待ち一覧へ戻る", admin_advice_suggestions_path, class: "admin-btn detail" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/advices/show.html.erb
+++ b/app/views/admin/advices/show.html.erb
@@ -1,0 +1,25 @@
+<div class="page-container admin-advices-page admin-advice-show">
+  <div class="page-header">
+    <h1><%= @advice.title %></h1>
+  </div>
+
+  <div class="page-body">
+    <% if notice.present? %>
+      <p class="notice"><%= notice %></p>
+    <% end %>
+
+    <p>カテゴリ：<%= @advice.category&.name %></p>
+    <p>更新：<%= l(@advice.updated_at) %></p>
+
+    <hr>
+
+    <div class="admin-show-body">
+      <%= simple_format(h(@advice.body)) %>
+    </div>
+
+    <div class="admin-actions" style="margin-top: 16px;">
+      <%= link_to "編集", edit_admin_advice_path(@advice), class: "admin-btn detail" %>
+      <%= link_to "一覧へ戻る", admin_advices_path, class: "admin-btn detail" %>
+    </div>
+  </div>
+</div>

--- a/app/views/advice_suggestions/index.html.erb
+++ b/app/views/advice_suggestions/index.html.erb
@@ -25,7 +25,8 @@
                   <span class="author"><%= s.user.display_name_or_email %></span>
                 </div>
 
-                <p class="submission-body"><%= s.body.truncate(80) %></p>
+                <!-- タイトルっぽく見せたいなら title/body を短く -->
+                <p class="submission-body"><%= (s.title.presence || s.body).truncate(80) %></p>
               <% end %>
             <% end %>
           </div>
@@ -41,6 +42,7 @@
         <% if @approved.any? %>
           <div class="submissions-list">
             <% @approved.each do |s| %>
+              <% published = s.advice %>
               <%= link_to advice_suggestion_path(s), class: "submission-card approved" do %>
                 <div class="submission-meta">
                   <div class="submission-meta-left">
@@ -50,7 +52,16 @@
                   <span class="author"><%= s.user.display_name_or_email %></span>
                 </div>
 
-                <p class="submission-body"><%= s.body.truncate(80) %></p>
+                <!--  掲載された内容があるならそれを表示 -->
+                <p class="submission-body">
+                  <%= (published&.title.presence || s.title.presence || s.body).truncate(80) %>
+                </p>
+
+                <% if published.present? %>
+                  <p class="submission-body is-sub">
+                    <%= published.body.to_s.truncate(80) %>
+                  </p>
+                <% end %>
               <% end %>
             <% end %>
           </div>
@@ -75,7 +86,7 @@
                   <span class="author"><%= s.user.display_name_or_email %></span>
                 </div>
 
-                <p class="submission-body"><%= s.body.truncate(80) %></p>
+                <p class="submission-body"><%= (s.title.presence || s.body).truncate(80) %></p>
               <% end %>
             <% end %>
           </div>

--- a/app/views/advice_suggestions/show.html.erb
+++ b/app/views/advice_suggestions/show.html.erb
@@ -4,9 +4,11 @@
   </div>
 
   <div class="page-body">
+    <% published = @advice_suggestion.advice %>
+
     <p>
-      <strong>カテゴリ：</strong>
-      <%= @advice_suggestion.category.name %>
+      <strong>タイトル：</strong>
+      <%= (published&.title.presence || @advice_suggestion.title.presence || "（タイトル未入力）") %>
     </p>
 
     <p>
@@ -21,9 +23,23 @@
 
     <hr>
 
-    <div class="submission-body">
-      <%= simple_format(@advice_suggestion.body) %>
-    </div>
+    <% if published.present? %>
+      <h2 class="submission-section-title">あなたの原文</h2>
+      <div class="submission-body">
+        <%= simple_format(h(@advice_suggestion.body)) %>
+      </div>
+
+      <hr>
+
+      <h2 class="submission-section-title">掲載された内容</h2>
+      <div class="submission-body">
+        <%= simple_format(h(published.body)) %>
+      </div>
+    <% else %>
+      <div class="submission-body">
+        <%= simple_format(h(@advice_suggestion.body)) %>
+      </div>
+    <% end %>
 
     <div class="submissions-actions">
       <%= link_to "一覧に戻る", advice_suggestions_path, class: "primary-btn" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,12 +14,19 @@ Rails.application.routes.draw do
 
   # 管理者
   namespace :admin do
-    resources :advice_suggestions, only: %i[index show] do
+    resources :advice_suggestions, only: %i[index show destroy] do
       member do
-        patch :approve
+        get  :new_advice
+        post :create_advice
+        patch :create_advice
         patch :reject
+        patch :restore
+        delete :delete_forever
+        # patch :approve --- APPROVEはcreate_adviceに統合 ---
       end
     end
+
+    resources :advices, only: %i[index show edit update destroy]
   end
 
   # ユーザー投稿

--- a/db/migrate/20260301073401_add_advice_suggestion_id_to_advices.rb
+++ b/db/migrate/20260301073401_add_advice_suggestion_id_to_advices.rb
@@ -1,0 +1,5 @@
+class AddAdviceSuggestionIdToAdvices < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :advices, :advice_suggestion, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_22_124634) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_01_073401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -61,6 +61,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_22_124634) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "seed_key"
+    t.bigint "advice_suggestion_id"
+    t.index ["advice_suggestion_id"], name: "index_advices_on_advice_suggestion_id"
     t.index ["category_id"], name: "index_advices_on_category_id"
   end
 
@@ -128,6 +130,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_22_124634) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "advice_suggestions", "categories"
   add_foreign_key "advice_suggestions", "users"
+  add_foreign_key "advices", "advice_suggestions"
   add_foreign_key "advices", "categories"
   add_foreign_key "favorites", "advices"
   add_foreign_key "favorites", "users"

--- a/tion_id: nil).destroy_all
+++ b/tion_id: nil).destroy_all
@@ -1,0 +1,140 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ESC-u                Undo (toggle) search highlighting.
+  ESC-U                Clear search highlighting.
+  &_p_a_t_t_e_r_n          *  Display only matching lines.
+        ---------------------------------------------------
+        A search pattern may begin with one or more of:
+        ^N or !  Search for NON-matching lines.
+        ^E or *  Search multiple files (pass thru END OF FILE).
+        ^F or @  Start search at FIRST file (for /) or last file (for ?).
+        ^K       Highlight matches, but don't move (KEEP position).
+        ^R       Don't use REGULAR EXPRESSIONS.
+        ^W       WRAP search if no match found.
+ ---------------------------------------------------------------------------
+
+                           JJUUMMPPIINNGG
+
+  g  <  ESC-<       *  Go to first line in file (or line _N).
+  G  >  ESC->       *  Go to last line in file (or line _N).
+  p  %              *  Go to beginning of file (or _N percent into file).
+  t                 *  Go to the (_N-th) next tag.
+  T                 *  Go to the (_N-th) previous tag.
+  {  (  [           *  Find close bracket } ) ].
+  }  )  ]           *  Find open bracket { ( [.
+  ESC-^F _<_c_1_> _<_c_2_>  *  Find close bracket _<_c_2_>.
+  ESC-^B _<_c_1_> _<_c_2_>  *  Find open bracket _<_c_1_>.
+        ---------------------------------------------------
+        Each "find close bracket" command goes forward to the close bracket 
+          matching the (_N-th) open bracket in the top line.
+        Each "find open bracket" command goes backward to the open bracket 
+          matching the (_N-th) close bracket in the bottom line.
+
+  m_<_l_e_t_t_e_r_>            Mark the current top line with <letter>.
+  M_<_l_e_t_t_e_r_>            Mark the current bottom line with <letter>.
+  '_<_l_e_t_t_e_r_>            Go to a previously marked position.
+  ''                   Go to the previous position.
+  ^X^X                 Same as '.
+  ESC-M_<_l_e_t_t_e_r_>        Clear a mark.
+        ---------------------------------------------------
+        A mark is any upper-case or lower-case letter.
+        Certain marks are predefined:
+             ^  means  beginning of the file
+             $  means  end of the file
+ ---------------------------------------------------------------------------
+
+                        CCHHAANNGGIINNGG FFIILLEESS
+
+  :e [_f_i_l_e]            Examine a new file.
+  ^X^V                 Same as :e.
+  :n                *  Examine the (_N-th) next file from the command line.
+  :p                *  Examine the (_N-th) previous file from the command line.
+  :x                *  Examine the first (or _N-th) file from the command line.
+  :d                   Delete the current file from the command line list.
+  =  ^G  :f            Print current file name.
+ ---------------------------------------------------------------------------
+
+                    MMIISSCCEELLLLAANNEEOOUUSS CCOOMMMMAANNDDSS
+
+  -_<_f_l_a_g_>              Toggle a command line option [see OPTIONS below].
+  --_<_n_a_m_e_>             Toggle a command line option, by name.
+  __<_f_l_a_g_>              Display the setting of a command line option.
+  ___<_n_a_m_e_>             Display the setting of an option, by name.
+  +_c_m_d                 Execute the less cmd each time a new file is examined.
+
+  !_c_o_m_m_a_n_d             Execute the shell command with $SHELL.
+  |XX_c_o_m_m_a_n_d            Pipe file between current pos & mark XX to shell command.
+  s _f_i_l_e               Save input to a file.
+  v                    Edit the current file with $VISUAL or $EDITOR.
+  V                    Print version number of "less".
+ ---------------------------------------------------------------------------
+
+                           OOPPTTIIOONNSS
+
+        Most options may be changed either on the command line,
+        or from within less by using the - or -- command.
+        Options may be given in one of two forms: either a single
+        character preceded by a -, or a name preceded by --.
+
+  -?  ........  --help
+                  Display help (from command line).
+  -a  ........  --search-skip-screen
+                  Search skips current screen.
+  -A  ........  --SEARCH-SKIP-SCREEN
+                  Search starts just after target line.
+  -b [_N]  ....  --buffers=[_N]
+                  Number of buffers.
+  -B  ........  --auto-buffers
+                  Don't automatically allocate buffers for pipes.
+  -c  ........  --clear-screen
+                  Repaint by clearing rather than scrolling.
+  -d  ........  --dumb
+                  Dumb terminal.
+  -D xx_c_o_l_o_r  .  --color=xx_c_o_l_o_r
+                  Set screen colors.
+  -e  -E  ....  --quit-at-eof  --QUIT-AT-EOF
+                  Quit at end of file.
+  -f  ........  --force
+                  Force open non-regular files.
+  -F  ........  --quit-if-one-screen


### PR DESCRIPTION
## 概要
「みんなのお悩み解決」投稿の承認後フローを実装。
承認 → Advice化 → 編集 → ユーザー側反映までの流れを構築。

## 変更内容
- 承認後にAdviceを作成/更新する処理を実装
- 原文（AdviceSuggestion）と掲載内容（Advice）の分離
- 管理画面のUI整理
- ユーザー側表示ロジックの修正
- N+1対策としてincludes(:advice)追加

## 背景
投稿と掲載内容の責務を明確化し、
アプリの二層構造（seed管理 / 投稿育成）を整理するため。

## 確認事項
- 承認後に編集内容がユーザー側へ反映されること
- ゴミ箱挙動の確認
- 一覧・詳細画面表示確認