### PR TITLE
GA4（Google Analytics）の導入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,15 @@
     <%= csp_meta_tag %>
     <%= yield :head %>
 
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-C7Q4HETPZ0"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-C7Q4HETPZ0');
+    </script>
+
     <!-- OGP設定 -->
     <meta property="og:title" content="フクちゃん学習掲示板">
     <meta property="og:description" content="学習の悩み・エラー・勉強法まで。後輩に届けるナレッジ共有アプリです。">
@@ -36,7 +45,6 @@
     data-controller="orientation"
     class="<%= yield(:body_class) %> <%= 'no-scroll' if controller_name == 'owls' && action_name == 'index' %>">
 
-    <%# auth_links は owls#index のみ表示 %>
     <% if controller_name == "owls" && action_name == "index" %>
       <%= render "shared/auth_links" %>
     <% end %>


### PR DESCRIPTION
## 概要
GA4（Google Analytics）を導入し、application.html.erbの<head>内に計測タグを追加しました。

## 目的
・ユーザーのアクセス状況を把握できる状態を整備するため  
・今後の改善施策（UI/UX改善や機能追加）の効果検証を行うため  

## 変更内容
・GA4タグを追加
・全ページで計測が行われるようレイアウトに反映

## 備考
現時点ではページビュー計測のみ実装。