### PR TITLE
READMEのOGP画像リンクと表記を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ https://www.figma.com/design/6qQWPIpktLOdYNcgOsizaL/%E7%94%BB%E9%9D%A2%E9%81%B7%
 ---
 
 ## 🖼️ OGP画像
-![フクちゃんお悩み掲示板](https://github.com/fuku-0420/owl-forest-app/blob/main/public/ogp.png?raw=true)
+![フクちゃん学習掲示板](https://github.com/fuku-0420/owl-forest-app/blob/main/public/ogp_v2.png?raw=true)
 
 ---
 


### PR DESCRIPTION
## 概要
README内のOGP画像表記を修正しました。

## 変更内容
- OGP画像のリンクを `ogp_v2.png` に変更
- alt文を `フクちゃん学習掲示板` に修正

## 目的
README内の記載を現在のOGP画像と表記に合わせるため