### PR TITLE
管理画面の承認操作ボタンの送信不具合を修正

### DIFF
--- a/app/views/admin/advice_suggestions/index.html.erb
+++ b/app/views/admin/advice_suggestions/index.html.erb
@@ -51,6 +51,7 @@
                     <%= button_to "却下",
                           reject_admin_advice_suggestion_path(s),
                           method: :patch,
+                          form: { data: { turbo: false } },
                           class: "admin-btn reject" %>
                   </div>
                 </td>
@@ -112,6 +113,7 @@
                     <%= button_to "ゴミ箱へ",
                           admin_advice_suggestion_path(s),
                           method: :delete,
+                          form: { data: { turbo: false } },
                           data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
                           class: "admin-btn danger" %>
                   </div>
@@ -167,6 +169,7 @@
                     <%= button_to "ゴミ箱へ",
                           admin_advice_suggestion_path(s),
                           method: :delete,
+                          form: { data: { turbo: false } },
                           data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
                           class: "admin-btn danger" %>
                   </div>
@@ -222,11 +225,14 @@
                     <%= button_to "復元",
                           restore_admin_advice_suggestion_path(s),
                           method: :patch,
+                          form: { data: { turbo: false } },
+                          data: { turbo_confirm: "ゴミ箱から復元します。よろしいですか？" },
                           class: "admin-btn detail" %>
 
                     <%= button_to "完全削除",
                           delete_forever_admin_advice_suggestion_path(s),
                           method: :delete,
+                          form: { data: { turbo: false } },
                           data: { turbo_confirm: "完全に削除します。元に戻せません。よろしいですか？" },
                           class: "admin-btn danger" %>
                   </div>

--- a/app/views/admin/advice_suggestions/show.html.erb
+++ b/app/views/admin/advice_suggestions/show.html.erb
@@ -77,6 +77,8 @@
           <%= button_to "却下",
                 reject_admin_advice_suggestion_path(@advice_suggestion),
                 method: :patch,
+                form: { data: { turbo: false } },
+                data: { turbo_confirm: "却下します。よろしいですか？" },
                 class: "admin-btn reject" %>
         <% end %>
 
@@ -92,6 +94,7 @@
           <%= button_to "ゴミ箱へ",
                 admin_advice_suggestion_path(@advice_suggestion),
                 method: :delete,
+                form: { data: { turbo: false } },
                 data: { turbo_confirm: "ゴミ箱に移動します。よろしいですか？" },
                 class: "admin-btn danger" %>
         <% end %>


### PR DESCRIPTION
## 概要
管理画面のアドバイス案一覧・詳細画面で、却下やゴミ箱移動などの操作ボタンが本番環境で正常に動作しない問題を修正しました。

## 変更内容
- 管理画面の `button_to` に `form: { data: { turbo: false } }` を追加
- 却下、ゴミ箱へ、復元、完全削除の操作を通常フォーム送信に変更

## 確認内容
- ローカル環境で以下の操作が問題なく動作することを確認
  - 却下
  - ゴミ箱へ
  - 復元
  - 完全削除

## 補足
本番環境でTurbo経由の送信時に422エラーが発生していたため、管理画面の状態変更操作ではTurboを無効化しました。